### PR TITLE
Phpstan tool

### DIFF
--- a/bin/githooks
+++ b/bin/githooks
@@ -1,7 +1,7 @@
-#!/usr/bin/env php
+#!/usr/bin/env php a
 <?php
 
-require getcwd() .'/vendor/autoload.php';
+require getcwd() . '/vendor/autoload.php';
 
 use GitHooks\Commands\{
     CheckConfigurationFileCommand,
@@ -18,7 +18,7 @@ use Illuminate\Container\Container;
 use Illuminate\Events\Dispatcher;
 use Illuminate\Console\Application;
 
-$container = new Container;
+$container = new Container();
 $events = new Dispatcher($container);
 
 $artisan = new Application($container, $events, 'Version 2.0');

--- a/bin/githooks
+++ b/bin/githooks
@@ -1,4 +1,4 @@
-#!/usr/bin/env php a
+#!/usr/bin/env php
 <?php
 
 require getcwd() . '/vendor/autoload.php';

--- a/qa/githooks.yml
+++ b/qa/githooks.yml
@@ -15,6 +15,7 @@ Tools:
 phpstan:
     config: './qa/phpstan-phpqa.neon'
     level: 8 #level 0-8 (0 default, 8 max)
+    paths: './src'
 
 #Se ejecuta contra la raiz del proyecto
 parallel-lint:

--- a/qa/githooks.yml
+++ b/qa/githooks.yml
@@ -15,7 +15,7 @@ Tools:
 phpstan:
     config: './qa/phpstan-phpqa.neon'
     level: 8 #level 0-8 (0 default, 8 max)
-    paths: './src'
+    #paths: ['./src']
 
 #Se ejecuta contra la raiz del proyecto
 parallel-lint:

--- a/qa/githooks.yml
+++ b/qa/githooks.yml
@@ -15,7 +15,7 @@ Tools:
 phpstan:
     config: './qa/phpstan-phpqa.neon'
     level: 8 #level 0-8 (0 default, 8 max)
-    #paths: ['./src']
+    paths: './src/Commands ./src/Exception' # array with blank space separation
 
 #Se ejecuta contra la raiz del proyecto
 parallel-lint:

--- a/qa/githooks.yml
+++ b/qa/githooks.yml
@@ -13,9 +13,9 @@ Tools:
 
 # Configuración de cada una de las herramientas
 phpstan:
+    paths: './src' # REQUIRED. Array with blank space separation.
     config: './qa/phpstan-phpqa.neon'
     level: 8 #level 0-8 (0 default, 8 max)
-    paths: './src/Commands ./src/Exception' # array with blank space separation
 
 #Se ejecuta contra la raiz del proyecto
 parallel-lint:

--- a/qa/phpstan-phpqa.neon
+++ b/qa/phpstan-phpqa.neon
@@ -2,11 +2,12 @@
 # currentWorkingDirectory es donde se ejecuta phpstan, en este caso desde ./
 {
     parameters: {
-        level: 8
-        paths: [
-            %currentWorkingDirectory%/src,
-            # %currentWorkingDirectory%/tests
-        ]
+        #level: 8 NO FUNCIONA
+        #paths: './src' NO FUNCIONA
+        # paths: [
+        #     %currentWorkingDirectory%/src,
+        #     # %currentWorkingDirectory%/tests
+        # ]
         checkMissingIterableValueType: false
         ignoreErrors: [
            # '#Result of method [a-zA-Z0-9\\_]+::toolShouldSkip\(\)#'

--- a/qa/phpstan-phpqa.neon
+++ b/qa/phpstan-phpqa.neon
@@ -2,6 +2,7 @@
 # currentWorkingDirectory es donde se ejecuta phpstan, en este caso desde ./
 {
     parameters: {
+        level: 8
         paths: [
             %currentWorkingDirectory%/src,
             # %currentWorkingDirectory%/tests

--- a/src/Tools/Stan.php
+++ b/src/Tools/Stan.php
@@ -58,9 +58,20 @@ class Stan extends ToolAbstract
 
     protected function prepareCommand(): string
     {
-        $config = '-c ' . $this->args[self::PHPSTAN_CONFIGURATION_FILE];
-        $level = '-l ' . $this->args[self::LEVEL];
-        $paths = $this->args[self::PATHS];
+        $config = '';
+        if(!empty($this->args[self::PHPSTAN_CONFIGURATION_FILE])){
+            $config = $this->args[self::PHPSTAN_CONFIGURATION_FILE];
+        }
+
+        $level = '';
+        if(!empty($this->args[self::LEVEL])){
+            $level = '-l ' . $this->args[self::LEVEL];
+        }
+        $paths = ''; // If path is empty phpStand will not work
+        if(!empty($this->args[self::PATHS])){
+            $paths = $this->args[self::PATHS];
+        }
+
         $arguments = " analyse $config --no-progress -n $level $paths";
         return $this->executable . $arguments;
     }
@@ -89,30 +100,19 @@ class Stan extends ToolAbstract
     public function setArguments($configurationFile)
     {
         if (!isset($configurationFile[Constants::PHPSTAN]) || empty($configurationFile[Constants::PHPSTAN])) {
-            throw new Exception("Clave phpstan no encontrada en githooks.yml");
+            $message = "Tool PhpStan not configured";
+            echo "\n" . $message . "\n";
             return;
         }
         $arguments = $configurationFile[Constants::PHPSTAN];
 
-        if (empty($arguments[self::PHPSTAN_CONFIGURATION_FILE])) {
-            throw new Exception("Clave config de phpstan no encontrada en githooks.yml");
-        } else {
+        if (!empty($arguments[self::PHPSTAN_CONFIGURATION_FILE])) {
             $this->args[self::PHPSTAN_CONFIGURATION_FILE] = $arguments[self::PHPSTAN_CONFIGURATION_FILE];
         }
-        var_dump($arguments);
-        if (empty($arguments[self::LEVEL])) {
-            //TODO Pablo: Leer el parámetro level del archivo de configuración de phpstan
-            echo "\n\n PhpStan tool: level configuration not found";
-            //$this->args[self::LEVEL] = '';
-        } else {
+        if (!empty($arguments[self::LEVEL])) {
             $this->args[self::LEVEL] = $arguments[self::LEVEL];
         }
-
-        if (empty($arguments[self::PATHS])) {
-            //TODO Pablo: probar qué pasa en este caso
-            echo "\n\n PhpStan tool: paths configuration not found";
-        } else {
-            //TODO Pablo: leer paths como array
+        if (!empty($arguments[self::PATHS])) {
             $this->args[self::PATHS] = $arguments[self::PATHS];
         }
     }

--- a/src/Tools/Stan.php
+++ b/src/Tools/Stan.php
@@ -61,10 +61,7 @@ class Stan extends ToolAbstract
         $config = '-c ' . $this->args[self::PHPSTAN_CONFIGURATION_FILE];
         $level = '-l ' . $this->args[self::LEVEL];
         $paths = $this->args[self::PATHS];
-        $paths = ["./src"];
-        $arguments = " analyse $config --no-progress -n $level ./src";
-        echo "\n\n COMMAND ARGUMENTS => ";
-        var_dump($arguments);
+        $arguments = " analyse $config --no-progress -n $level $paths";
         return $this->executable . $arguments;
     }
 

--- a/src/Tools/Stan.php
+++ b/src/Tools/Stan.php
@@ -4,6 +4,7 @@ namespace GitHooks\Tools;
 
 use GitHooks\Constants;
 use GitHooks\Tools\Exception\ExitErrorException;
+use Exception;
 
 /**
  * Ejecuta la libreria phpstan/phpstan
@@ -32,7 +33,7 @@ class Stan extends ToolAbstract
      */
     protected $args;
 
-     public function __construct(array $configurationFile)
+    public function __construct(array $configurationFile)
     {
         $this->installer = 'phpstan/phpstan';
 
@@ -59,8 +60,11 @@ class Stan extends ToolAbstract
     {
         $config = '-c ' . $this->args[self::PHPSTAN_CONFIGURATION_FILE];
         $level = '-l ' . $this->args[self::LEVEL];
-        $path = $this->args[self::PATHS];
-        $arguments = " analyse $config --no-progress -n $level $path";
+        $paths = $this->args[self::PATHS];
+        $paths = ["./src"];
+        $arguments = " analyse $config --no-progress -n $level ./src";
+        echo "\n\n COMMAND ARGUMENTS => ";
+        var_dump($arguments);
         return $this->executable . $arguments;
     }
 
@@ -88,24 +92,21 @@ class Stan extends ToolAbstract
     public function setArguments($configurationFile)
     {
         if (!isset($configurationFile[Constants::PHPSTAN]) || empty($configurationFile[Constants::PHPSTAN])) {
-            //TODO Pablo: probar qué pasa en este caso
-            $this->args = [];
-            echo "\n\n PhpStan tool: Not detected arguments";
+            throw new Exception("Clave phpstan no encontrada en githooks.yml");
             return;
         }
         $arguments = $configurationFile[Constants::PHPSTAN];
 
         if (empty($arguments[self::PHPSTAN_CONFIGURATION_FILE])) {
-            //TODO Pablo: probar qué pasa en este caso
-            echo "PhpStan tool: configuration file not found";
+            throw new Exception("Clave config de phpstan no encontrada en githooks.yml");
         } else {
-            // args está vacío
             $this->args[self::PHPSTAN_CONFIGURATION_FILE] = $arguments[self::PHPSTAN_CONFIGURATION_FILE];
         }
-
+        var_dump($arguments);
         if (empty($arguments[self::LEVEL])) {
-            //TODO Pablo: probar qué pasa en este caso
+            //TODO Pablo: Leer el parámetro level del archivo de configuración de phpstan
             echo "\n\n PhpStan tool: level configuration not found";
+            //$this->args[self::LEVEL] = '';
         } else {
             $this->args[self::LEVEL] = $arguments[self::LEVEL];
         }

--- a/src/Tools/Stan.php
+++ b/src/Tools/Stan.php
@@ -20,6 +20,11 @@ class Stan extends ToolAbstract
      */
     public const LEVEL = 'level';
 
+    /**
+     * @var string PATHS Tag que indica sobre qué carpetas se debe ejecutar el análisis de phpstan en el fichero de configuracion .yml
+     */
+    public const PATHS = 'paths';
+
     public const OPTIONS = [self::PHPSTAN_CONFIGURATION_FILE, self::LEVEL];
 
     /**
@@ -27,7 +32,7 @@ class Stan extends ToolAbstract
      */
     protected $args;
 
-    public function __construct(array $configurationFile)
+     public function __construct(array $configurationFile)
     {
         $this->installer = 'phpstan/phpstan';
 
@@ -54,8 +59,8 @@ class Stan extends ToolAbstract
     {
         $config = '-c ' . $this->args[self::PHPSTAN_CONFIGURATION_FILE];
         $level = '-l ' . $this->args[self::LEVEL];
-        $arguments = " analyse $config --no-progress -n $level ./src";
-
+        $path = $this->args[self::PATHS];
+        $arguments = " analyse $config --no-progress -n $level $path";
         return $this->executable . $arguments;
     }
 
@@ -82,29 +87,35 @@ class Stan extends ToolAbstract
      */
     public function setArguments($configurationFile)
     {
-        $defaultConfig = './qa/phpstan-phpqa.neon';
-        $defaultLevel = 1;
-
         if (!isset($configurationFile[Constants::PHPSTAN]) || empty($configurationFile[Constants::PHPSTAN])) {
-            $this->args = [
-                self::PHPSTAN_CONFIGURATION_FILE => $defaultConfig,
-                self::LEVEL => $defaultLevel,
-            ];
+            //TODO Pablo: probar qué pasa en este caso
+            $this->args = [];
+            echo "\n\n PhpStan tool: Not detected arguments";
             return;
         }
-
         $arguments = $configurationFile[Constants::PHPSTAN];
 
         if (empty($arguments[self::PHPSTAN_CONFIGURATION_FILE])) {
-            $this->args[self::PHPSTAN_CONFIGURATION_FILE] = $defaultConfig;
+            //TODO Pablo: probar qué pasa en este caso
+            echo "PhpStan tool: configuration file not found";
         } else {
+            // args está vacío
             $this->args[self::PHPSTAN_CONFIGURATION_FILE] = $arguments[self::PHPSTAN_CONFIGURATION_FILE];
         }
 
         if (empty($arguments[self::LEVEL])) {
-            $this->args[self::LEVEL] = $defaultLevel;
+            //TODO Pablo: probar qué pasa en este caso
+            echo "\n\n PhpStan tool: level configuration not found";
         } else {
             $this->args[self::LEVEL] = $arguments[self::LEVEL];
+        }
+
+        if (empty($arguments[self::PATHS])) {
+            //TODO Pablo: probar qué pasa en este caso
+            echo "\n\n PhpStan tool: paths configuration not found";
+        } else {
+            //TODO Pablo: leer paths como array
+            $this->args[self::PATHS] = $arguments[self::PATHS];
         }
     }
 }


### PR DESCRIPTION
Primera versión de la parametrización de la tool PhpStand.
Parámetros: paths, config, level

Parámetros paths es obligatorio, el resto opcionales.
El level por defecto cuando no está especificado en githooks.yml es 0, aunque se ponga otro valor en el fichero .neon.

Se muestra un mensaje informativo cuando la configuración de la tool es incorrecta (no se encuentra la clave phpstan o la clave existe para la configuración está vacía).