### PR TITLE
Executable finder fix

### DIFF
--- a/src/Tools/CheckSecurity.php
+++ b/src/Tools/CheckSecurity.php
@@ -23,33 +23,4 @@ class CheckSecurity extends ToolAbstract
     {
         return $this->executable;
     }
-
-    /**
-     * Devuelve la primera versión del ejecutable que encuentra (como .phar, en local o global). Si no encuentra ninguna versión lanza excepción.
-     * Sobreescritura del método padre.
-     *
-     * @return string Ruta completa al ejecutable. Si no lo encuentra lanza una ExecutableNotFoundException
-     */
-    protected function executableFinder(): string
-    {
-        //TODO por un lado el composer puede estar a nivel global o puede ser un phar y por otro lado el ejecutable
-        // $phar = 'php composer.phar show ' . $this->installer;
-        $local = 'composer show ' . $this->installer;
-        $global = 'composer global show ' . $this->installer;
-
-        // if ($this->libraryCheck($phar)) {
-        //     return  $this->executable . '.phar';
-        // }
-
-        if ($this->libraryCheck($local)) {
-            return $this->executable;
-        }
-
-        if ($this->libraryCheck($global)) {
-            $this->executable = 'composer global check-security';
-            return $this->executable;
-        }
-
-        throw ExecutableNotFoundException::forExec($this->executable);
-    }
 }

--- a/src/Tools/ParallelLint.php
+++ b/src/Tools/ParallelLint.php
@@ -3,6 +3,7 @@
 namespace GitHooks\Tools;
 
 use GitHooks\Constants;
+use GitHooks\Tools\Exception\ExecutableNotFoundException;
 
 /**
  * Ejecuta la libreria jakub-onderka/php-parallel-lint
@@ -42,6 +43,27 @@ class ParallelLint extends ToolAbstract
 
         //parallel-lint ./ --exclude qa --exclude tests --exclude vendor
         return $this->executable . $arguments;
+    }
+
+    /**
+     * Devuelve la primera versión del ejecutable que encuentra. La prioridad de búsqueda es local > .phar > global . Si no encuentra ninguna versión lanza excepción.
+     *
+     * @return string Ruta completa al ejecutable. Si no lo encuentra lanza una ExecutableNotFoundException
+     */
+    protected function executableFinder(): string
+    {
+        try {
+            return parent::executableFinder();
+        } catch (\Throwable $th) {
+            if ('php-parallel-lint/php-parallel-lint' === $this->installer) {
+                $global = 'composer global show jakub-onderka/php-parallel-lint';
+    
+                if ($this->libraryCheck($global)) {
+                    return $this->executable;
+                }
+            }
+            throw ExecutableNotFoundException::forExec($this->executable);
+        }
     }
 
     /**

--- a/src/Tools/ParallelLint.php
+++ b/src/Tools/ParallelLint.php
@@ -57,7 +57,7 @@ class ParallelLint extends ToolAbstract
         } catch (\Throwable $th) {
             if ('php-parallel-lint/php-parallel-lint' === $this->installer) {
                 $global = 'composer global show jakub-onderka/php-parallel-lint';
-    
+
                 if ($this->libraryCheck($global)) {
                     return $this->executable;
                 }

--- a/src/Tools/ToolAbstract.php
+++ b/src/Tools/ToolAbstract.php
@@ -49,31 +49,83 @@ abstract class ToolAbstract
      */
     protected function executableFinder(): string
     {
-        //TODO por un lado el composer puede estar a nivel global o puede ser un phar y por otro lado el ejecutable
-        // $phar = 'php composer.phar show ' . $this->installer;
-        $local = 'composer show ' . $this->installer;
-        $global = 'composer global show ' . $this->installer;
-        $root = getcwd();
-        // if ($this->libraryCheck($phar)) {
-        //     return  $this->executable . '.phar';
-        // }
+        //Step 1: Local
+        //Search executable in vendor/bin
+        // Case 1: tested
+        $path = $this->searchInVendor();
+        if(!empty($path)) return $path;
 
+        //Search executable .phar in project root
+        // Case 2: tested
+        $path = $this->searchPhar();
+        if(!empty($path)) return $path;
+
+        //Step 2 : Global
+        // Search executable globally
+        
+        // Unix command for linux and MacOS
+        // Case 3: tested
+        $command = 'which ' . $this->executable;
+        $exitArray =  $exitCode = null;
+        exec($command, $exitArray, $exitCode);
+        if($exitCode == 0 && !empty($exitArray)){
+            return $exitArray[0];
+        }
+
+        // TODO Pablo try where (Windows)
+        // Windows command
+        // Case 4: TODO
+        // Option 1: Search in $PATH
+        // How to search executables in windows path :
+        // c:\> for %i in (cmd.exe) do @echo.   %~$PATH:i
+        //     C:\WINDOWS\system32\cmd.exe
+        // c:\> for %i in (python.exe) do @echo.   %~$PATH:i
+        //     C:\Python25\python.exe
+
+        // Option 2: powershell Get-Command or gcm as mentioned in another answer is equivalent to where
+
+        // Option 3: where command
+        //C:\Windows\System32\where.exe
+        // where may return several values, the first one will be the one invoked
+        // Remember that where.exe is not a shell builtin, you need to have %windir%\system32 on your %PATH% - which may not be the case, as using where suggests that you may be working on problems with your path
+
+        // Option 4: Windows which implmentantion (batch file) : https://ss64.com/nt/syntax-which.html
+        $command = 'where.exe ' . $this->executable;
+        $exitArray =  $exitCode = null;
+        exec($command, $exitArray, $exitCode);
+        if($exitCode == 0 && !empty($exitArray)){
+            return $exitArray[0];
+        }
+
+        //Step 3 : Composer dependency
+        // TODO Pablo test composer show
+        // Case 5: To test
+        echo "composer \n";
+        $local = 'composer show ' . $this->installer;
         if ($this->libraryCheck($local)) {
+            echo 'VENDOR';
             return 'vendor/bin/' . $this->executable;
         }
 
+        // Case 6: Tested
+        $global = 'composer global show ' . $this->installer;
+        
         if ($this->libraryCheck($global)) {
             return $this->executable;
         }
 
+        //TODO Pablo to test
+        $root = getcwd();
         if ('php-parallel-lint/php-parallel-lint' === $this->installer) {
             $local = 'composer show jakub-onderka/php-parallel-lint';
             $global = 'composer global show jakub-onderka/php-parallel-lint';
 
+            // Repeat case 5 with old vendor
             if ($this->libraryCheck($local)) {
                 return $root . '/vendor/bin/' . $this->executable;
             }
 
+            // Repeat case 6 with old vendor
             if ($this->libraryCheck($global)) {
                 return $this->executable;
             }
@@ -216,5 +268,37 @@ abstract class ToolAbstract
     public function getErrors(): string
     {
         return $this->errors;
+    }
+
+    /**
+     * Devuelve la primera versión del ejecutable que encuentra (como .phar, en local o global). Si no encuentra ninguna versión lanza excepción.
+     *
+     * @return string Ruta completa al ejecutable. Si no lo encuentra lanza una ExecutableNotFoundException
+     */
+    private function searchInVendor() {
+        $path = '';
+        $command = 'vendor/bin/' . $this->executable . ' --version';
+        $exitArray =  $exitCode = null;
+        exec($command, $exitArray, $exitCode);
+        if($exitCode == 0 && !empty($exitArray)){
+            $path = 'vendor/bin/'. $this->executable;
+        }
+        return $path;
+    }
+
+    /**
+     * Devuelve la primera versión del ejecutable que encuentra (como .phar, en local o global). Si no encuentra ninguna versión lanza excepción.
+     *
+     * @return string Ruta completa al ejecutable. Si no lo encuentra lanza una ExecutableNotFoundException
+     */
+    private function searchPhar() {
+        $path = '';
+        $command = 'php ' . $this->executable . '.phar --version';
+        $exitArray =  $exitCode = null;
+        exec($command, $exitArray, $exitCode); // 127 when error, 0 when OK
+        if($exitCode == 0 && !empty($exitArray)){
+            $path = 'php '. $this->executable . '.phar';
+        }
+        return $path;
     }
 }


### PR DESCRIPTION
Reimplementation of executableFinder.

Search order:
    1. vendor/bin
    2. .phar in project
    3. composer global
    4. global (for unix-like systems)

Added parallel-lint second vendor name in parallel-lint self class.
