### PR TITLE
Checksecurity  is run whenever it is configured (in the 'Tools' tag) in both Smartstrategy and Fullstrategy

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -7,6 +7,10 @@
     {
         "name": "Jorge Lilao",
         "email": "jorgelilaoc@gmail.com"
+    },
+    {
+      "name": "Pablo Lilao",
+      "email": "pablolilao@protonmail.com"
     }
 ],
   "autoload": {

--- a/src/LoadTools/SmartStrategy.php
+++ b/src/LoadTools/SmartStrategy.php
@@ -73,12 +73,9 @@ class SmartStrategy implements StrategyInterface
     protected function toolShouldSkip(string $tool): bool
     {
         $toolShouldSkip = false;
-        if (Constants::CHECK_SECURITY === $tool) {
-            $toolShouldSkip = ! $this->gitFiles->isComposerModified();
-        } else {
+        if (Constants::CHECK_SECURITY !== $tool) {
             $toolShouldSkip = $this->toolHasExclusionsConfigured($tool) && $this->allModifiedFilesAreExcluded($tool);
         }
-
         return $toolShouldSkip;
     }
 

--- a/src/Utils/GitFiles.php
+++ b/src/Utils/GitFiles.php
@@ -16,21 +16,4 @@ class GitFiles
 
         return $modifiedFiles;
     }
-
-    /**
-     * Comprueba que composer.json o composer.lock han sido modificados
-     *
-     * @return boolean. True cuando se ha modificado alguna librería de composer.
-     */
-    public function isComposerModified(): bool
-    {
-        //TODO Corregir el error que hace que por pantalla se muestre sh: 1: Syntax error: Unterminated quoted string
-        $composer = shell_exec('git diff --cached --name-only --diff-filter=ACM |^composer.json$\\|^composer.lock$');
-
-        if (empty($composer)) {
-            return false;
-        }
-
-        return true;
-    }
 }

--- a/tests/Unit/LoadTools/SmartStrategyTest.php
+++ b/tests/Unit/LoadTools/SmartStrategyTest.php
@@ -236,10 +236,7 @@ class SmartStrategyTest extends TestCase
             'Tools' => ['check-security'],
         ];
 
-        $gitFiles = Mockery::mock(GitFiles::class);
-        $gitFiles->shouldReceive('isComposerModified')->andReturn(true);
-
-        $smartStrategy = new SmartStrategy($configurationFile, $gitFiles, new ToolsFactoy());
+        $smartStrategy = new SmartStrategy($configurationFile, new GitFiles(), new ToolsFactoy());
 
         $loadedTools = $smartStrategy->getTools();
 


### PR DESCRIPTION
- Before: check-security did not run when Smartstrategy was enabled and there were NO changes to either composer.json or composer.lock.
- Now: chec-security is run whenever it is configured (in the 'Tools' tag) in both Smartstrategy and Fullstrategy.
