### PR TITLE
Fix phpmd silent errors

### DIFF
--- a/src/Commands/ToolCommandExecutor.php
+++ b/src/Commands/ToolCommandExecutor.php
@@ -4,7 +4,6 @@ namespace GitHooks\Commands;
 
 use GitHooks\Configuration;
 use GitHooks\Constants;
-use GitHooks\Tools\ToolAbstract;
 use GitHooks\Tools\ToolExecutor;
 use GitHooks\Tools\ToolsFactoy;
 

--- a/src/Tools/CheckSecurity.php
+++ b/src/Tools/CheckSecurity.php
@@ -2,8 +2,6 @@
 
 namespace GitHooks\Tools;
 
-use GitHooks\Tools\Exception\ExecutableNotFoundException;
-
 /**
  * Ejecuta la libreria funkjedi/composer-plugin-security-check
  * Encuentra vulnerabilidades en dependencias de composer.

--- a/src/Tools/MessDetector.php
+++ b/src/Tools/MessDetector.php
@@ -59,9 +59,9 @@ class MessDetector extends ToolAbstract
             $path = implode(',', $this->args[self::PATHS]);
         }
 
-        $arguments = " $path text $rules $exclude";
+        $arguments = " $path ansi $rules $exclude";
 
-        //text ./qa/md-rulesheet.xml --exclude "vendor,tests,views"
+        // ./src/ ansi ./qa/phpmd-src-ruleset.xml --exclude "vendor"
         return $this->executable . $arguments;
     }
 
@@ -90,5 +90,32 @@ class MessDetector extends ToolAbstract
         if (!empty($arguments[self::PATHS])) {
             $this->args[self::PATHS] = $this->routeCorrector($arguments[self::PATHS]);
         }
+    }
+
+      /**
+     * Método donde se ejecuta la herramienta mediante exec. La herramienta no producirá ninguna salida.
+     *
+     * @return void
+     */
+    public function execute()
+    {
+        parent::execute();
+        if ($this->exitCode == 0 && $this->isThereHiddenError()) {
+            $this->exitCode = 1;
+        }
+    }
+
+    /**
+     * Check if the exit of Mess detector is OK.
+     * If there is an error in the source file that prevents Mess detector from parsing it, Mess detector will return an exit code 0.
+     * But mess detector will not be able to check that file. 
+     *
+     * @return bool
+     */
+    protected function isThereHiddenError(){
+        if(is_int(strpos($this->exit[3], 'No mess detected'))){
+            return false;
+        }
+        return true;
     }
 }

--- a/src/Tools/MessDetector.php
+++ b/src/Tools/MessDetector.php
@@ -108,12 +108,13 @@ class MessDetector extends ToolAbstract
     /**
      * Check if the exit of Mess detector is OK.
      * If there is an error in the source file that prevents Mess detector from parsing it, Mess detector will return an exit code 0.
-     * But mess detector will not be able to check that file. 
+     * But mess detector will not be able to check that file.
      *
      * @return bool
      */
-    protected function isThereHiddenError(){
-        if(is_int(strpos($this->exit[3], 'No mess detected'))){
+    protected function isThereHiddenError()
+    {
+        if (is_int(strpos($this->exit[3], 'No mess detected'))) {
             return false;
         }
         return true;

--- a/src/Tools/Stan.php
+++ b/src/Tools/Stan.php
@@ -54,11 +54,7 @@ class Stan extends ToolAbstract
 
         exec($this->prepareCommand(), $this->exit, $this->exitCode);
 
-        $this->exitCode = 0;
-
         $this->isCrashed();
-
-        $this->exit = [];
     }
 
     protected function prepareCommand(): string

--- a/src/Tools/ToolAbstract.php
+++ b/src/Tools/ToolAbstract.php
@@ -20,12 +20,12 @@ abstract class ToolAbstract
     /**
      * @var int
      */
-    protected $exitCode;
+    protected $exitCode = -1;
 
     /**
      * @var array
      */
-    protected $exit;
+    protected $exit = '';
 
     //TODO Creo que esta variable solo contiene errores al buscar el ejecutable
     /**
@@ -123,7 +123,6 @@ abstract class ToolAbstract
      */
     protected function routeCorrector(array $paths)
     {
-
         if (! $this->isWindows()) {
             return $paths;
         }
@@ -173,21 +172,6 @@ abstract class ToolAbstract
     }
 
     abstract protected function prepareCommand(): string;
-
-    /**
-     * Muestra los errores obtenidos por la herramienta. Es posible que una herramienta termine de forma inesperada.
-     * En estos casos no se mostrara nada.
-     *
-     * @return void
-     */
-    public function printErrors()
-    {
-        if (is_array($this->getExit())) {
-            foreach ($this->getExit() as $line) {
-                echo "\n$line";
-            }
-        }
-    }
 
     public function getExecutable(): string
     {

--- a/src/Tools/ToolAbstract.php
+++ b/src/Tools/ToolAbstract.php
@@ -25,7 +25,7 @@ abstract class ToolAbstract
     /**
      * @var array
      */
-    protected $exit = '';
+    protected $exit = [];
 
     //TODO Creo que esta variable solo contiene errores al buscar el ejecutable
     /**

--- a/src/Tools/ToolExecutor.php
+++ b/src/Tools/ToolExecutor.php
@@ -70,7 +70,6 @@ class ToolExecutor
                 $this->printer->resultWarning($message);
             } catch (ExitErrorException $th) {
                 $this->printErrors($tool);
-                //TODO a lo mejor cuando revienta una herramienta queremos mostrar el stacktraces para poder corregir la configuración de la herramienta. Esto viene de PHPStan
                 $endToolTime = microtime(true);
                 $executionToolTime = ($endToolTime - $startToolTime);
                 $exitCode = self::KO;
@@ -95,7 +94,7 @@ class ToolExecutor
      *
      * @return void
      */
-    public function printErrors($tool)
+    public function printErrors(ToolAbstract $tool)
     {
         if (is_array($tool->getExit())) {
             foreach ($tool->getExit() as $line) {

--- a/src/Tools/ToolExecutor.php
+++ b/src/Tools/ToolExecutor.php
@@ -47,20 +47,20 @@ class ToolExecutor
                 } else {
                     $tool->execute();
                 }
-
                 $endToolTime = microtime(true);
                 $executionToolTime = ($endToolTime - $startToolTime);
                 $time = number_format($executionToolTime, 2);
-
                 if ($tool->getExitCode() === self::OK) {
                     $message = $this->getSuccessString($tool->getExecutable(), $time);
                     $this->printer->resultSuccess($message);
                 } else {
+                    $this->printErrors($tool);
                     $exitCode = self::KO;
                     $message = $this->getErrorString($tool->getExecutable(), $time);
                     $this->printer->resultError($message);
                 }
             } catch (ModifiedButUnstagedFilesException $ex) {
+                $this->printErrors($tool);
                 $endToolTime = microtime(true);
                 $executionToolTime = ($endToolTime - $startToolTime);
                 $time = number_format($executionToolTime, 2);
@@ -69,6 +69,7 @@ class ToolExecutor
                 $message = $this->getSuccessString($tool->getExecutable(), $time) . '. Se han modificado algunos ficheros. Por favor, añádelos al stage y vuelve a commitear.';
                 $this->printer->resultWarning($message);
             } catch (ExitErrorException $th) {
+                $this->printErrors($tool);
                 //TODO a lo mejor cuando revienta una herramienta queremos mostrar el stacktraces para poder corregir la configuración de la herramienta. Esto viene de PHPStan
                 $endToolTime = microtime(true);
                 $executionToolTime = ($endToolTime - $startToolTime);
@@ -77,14 +78,30 @@ class ToolExecutor
                 $message = $this->getErrorString($tool->getExecutable(), $time);
                 $this->printer->resultError($message);
             } catch (\Throwable $th) {
+                $this->printErrors($tool);
                 $exitCode = self::KO;
                 $message = "Error en la ejecución de $tool->getExecutable(). \n";
-                $this->printer->resultError($message);
                 $this->printer->line($th->getMessage());
+                $this->printer->resultError($message);
             }
         }
 
         return $exitCode;
+    }
+
+    /**
+     * Muestra los errores obtenidos por la herramienta. Es posible que una herramienta termine de forma inesperada.
+     * En estos casos no se mostrara nada.
+     *
+     * @return void
+     */
+    public function printErrors($tool)
+    {
+        if (is_array($tool->getExit())) {
+            foreach ($tool->getExit() as $line) {
+                $this->printer->line($line);
+            }
+        }
     }
 
     protected function getErrorString(string $tool, string $time): string

--- a/tests/Unit/GitHooksTest.php
+++ b/tests/Unit/GitHooksTest.php
@@ -35,7 +35,6 @@ class GitHooksTest extends TestCase
     function prueba()
     {
         $this->markTestSkipped("Pruebas de integracion con exit 1");
-        var_dump("\n==============================");
         $a = $this->getFile('src/parallel-lintOK.php');
         var_dump($a);
         $mockParallelLint = m::mock(ParallelLint::class)->makePartial();

--- a/tests/Unit/LoadTools/SmartStrategyTest.php
+++ b/tests/Unit/LoadTools/SmartStrategyTest.php
@@ -541,8 +541,6 @@ class SmartStrategyTest extends TestCase
         $this->assertArrayHasKey('phpstan', $loadedTools);
 
         $this->assertArrayHasKey('check-security', $loadedTools);
-
-        
     }
 
     /**


### PR DESCRIPTION
- Print errors when tool execution exits with non-zero
- MessDetector overrides execute to change exit to -1 when the exit is different of "No mess detected"
- Initialization of exit and exitCode in ToolAbstract
- MessDetector configured to ansi
